### PR TITLE
Fixed bugs relating to opening files and numerical inputs

### DIFF
--- a/pkg/retistruct/R/server-handlers.R
+++ b/pkg/retistruct/R/server-handlers.R
@@ -75,7 +75,20 @@ set.status <- function(output, ...) {
 
 plotProjection <- function(max.proj.dim=getOption("max.proj.dim"),
                            markup=NULL, state, input) {
-  
+  if (is.na(input$center.el) || is.na(input$center.az)) {
+    showNotification("Value(s) in projection centre is not a number,
+                     stopping reconstruction. (You cannot do numerical
+                     computations within the input box)", type="error")
+    return()
+  }
+  if (is.na(input$ax.el) || is.na(input$ax.az)) {
+    showNotification("Value(s) in axis direction is not a number,
+                     stopping reconstuction. (You cannot do numerical
+                     computations within the input box)", type="error")
+
+    return()
+  }
+
   if (is.null(markup)) {
     markup <- ("markup" %in% input$show)
   }
@@ -276,6 +289,20 @@ h.save <- function(h, state, ...) {
 
 ## Handler for reconstruction
 h.reconstruct <- function(h, state, input, output, session, ...) {
+  if (is.na(input$center.el) || is.na(input$center.az)) {
+    showNotification("Value(s) in projection centre is not a number,
+                     stopping reconstruction. (You cannot do numerical
+                     computations within the input box)", type="error")
+    return()
+  }
+  if (is.na(input$ax.el) || is.na(input$ax.az)) {
+    showNotification("Value(s) in axis direction is not a number,
+                     stopping reconstuction. (You cannot do numerical
+                     computations within the input box)", type="error")
+
+    return()
+  }
+
   unsaved.data(TRUE, state)
   enable.widgets(FALSE, state)
   catchErrorsRecordWarnings({
@@ -529,16 +556,14 @@ save.pdf <- function(state, input, output, session, file, left) {
 ## ---------- Warning and error handlers  ----------
 # Error Message
 h.error <- function(e, session) {
-  showNotification(conditionMessage(e), duration=NULL, closeButton=TRUE,
-                   type="error", session=session)
+  showNotification(conditionMessage(e), duration=10, type="error", session=session)
 }
 
 ## Warning message
 h.warning <- function(w, state, session) {
   e <- conditionMessage(w)
   if (!(any(e %in% state$prior.warnings))) {
-    showNotification(e, duration=NULL, closeButton=TRUE, type="warning",
-                     session=session)
+    showNotification(e, duration=10, type="warning", session=session)
     state$prior.warnings <- c(state$prior.warnings, e)
   }
 }

--- a/pkg/retistruct/R/server.R
+++ b/pkg/retistruct/R/server.R
@@ -53,7 +53,9 @@ server <- function(input, output, session) {
     dirname <- parseDirPath(roots=directories, input$open)
     if (length(dirname) > 0) {
       state$dataset <- dirname
-      h.open(state=state, input=input, output=output, session=session)
+      tryCatch({
+        h.open(state=state, input=input, output=output, session=session)
+      }, error=function(e) return())
     }
   })
   
@@ -152,8 +154,8 @@ server <- function(input, output, session) {
     ## Stops enabling widgets if no directory
     tryCatch({
       h.demo2(state, input, output, session, extdata.demos, "Figure_6-data", "left-contra")
-      enable.widgets(TRUE, state)
     }, error=function(e){return()})
+    enable.widgets(TRUE, state)
   })
   
   observeEvent(input$fig6li, {
@@ -161,8 +163,8 @@ server <- function(input, output, session) {
     removeModal()
     tryCatch({
       h.demo2(state, input, output, session, extdata.demos, "Figure_6-data", "left-ipsi")
-      enable.widgets(TRUE, state)
     }, error=function(e){return()})
+    enable.widgets(TRUE, state)
   })
   
   observeEvent(input$fig6rc, {
@@ -170,8 +172,8 @@ server <- function(input, output, session) {
     removeModal()
     tryCatch({
       h.demo2(state, input, output, session, extdata.demos, "Figure_6-data", "right-contra")
-      enable.widgets(TRUE, state)
     }, error=function(e){return()})
+    enable.widgets(TRUE, state)
   })
   
   observeEvent(input$fig6ri, {
@@ -179,8 +181,8 @@ server <- function(input, output, session) {
     removeModal()
     tryCatch({
       h.demo2(state, input, output, session, extdata.demos, "Figure_6-data", "right-ipsi")
-      enable.widgets(TRUE, state)
     }, error=function(e){return()})
+    enable.widgets(TRUE, state)
   })
   
   ## About button handler
@@ -356,6 +358,11 @@ server <- function(input, output, session) {
   
   # phi0 handler
   observeEvent(input$phi0, {
+    if (is.na(input$phi0)) {
+      showNotification("Value in phi0 is not a number, phi0 is unchanged.
+                       (You cannot do numerical computations within the input box)", type="error")
+      return()
+    }
     unsaved.data(TRUE, state)
     v <- input$phi0
     if (v < -80) {


### PR DESCRIPTION
- Fixed app crashing when a folder with no reconstruction was opened.
- Fixed buttons being permanently disabled when retistructdemos package wasn't installed on system.
- Fixed app crash when a numerical input was an expression (0+2, 0-).
- Added a 10s timeout to all errors and warnings.